### PR TITLE
Only lint JavaScript belonging to the tested page

### DIFF
--- a/lib/harAnalyzer.js
+++ b/lib/harAnalyzer.js
@@ -29,6 +29,47 @@ export class HarAnalyzer {
         this.dependencies = this.package.dependencies;
         this.version = this.package.version;
     }
+    getFirstPageEntries(url, harData) {
+        if ('log' in harData) {
+            harData = harData['log'];
+        }
+
+        const entries = harData.entries;
+        if (!Array.isArray(entries)) {
+            return [];
+        }
+
+        // A HAR can contain more than one page, for example when a concurrent
+        // browsertime run ends up in the same browser session (crossed DevTools
+        // port) and navigates to another website mid-recording. Requests made
+        // by other pages must not be attributed to the tested website, and if
+        // the recording doesn't even start with the tested website nothing in
+        // it can be trusted.
+        if (url && entries.length > 0) {
+            const firstUrl = entries[0].request && entries[0].request.url;
+            if (firstUrl) {
+                try {
+                    if (new URL(firstUrl).hostname !== new URL(url).hostname) {
+                        return [];
+                    }
+                } catch {
+                    // Unparsable URLs are handled by the entry loops as before
+                }
+            }
+        }
+
+        const pages = harData.pages;
+        if (!Array.isArray(pages) || pages.length === 0) {
+            return entries;
+        }
+        const firstPageId = pages[0].id;
+        if (firstPageId === undefined) {
+            return entries;
+        }
+        return entries.filter(entry =>
+            entry.pageref === undefined || entry.pageref === firstPageId);
+    }
+
     transform2SimplifiedData(harData, url) {
         const data = {
             'url': url,
@@ -41,13 +82,9 @@ export class HarAnalyzer {
             'script-files': []
         };
 
-        if ('log' in harData) {
-            harData = harData['log'];
-        }
-
         let reqIndex = 1;
 
-        for (const entry of harData.entries) {
+        for (const entry of this.getFirstPageEntries(url, harData)) {
             const req = entry.request;
             const res = entry.response;
             const reqUrl = req.url;


### PR DESCRIPTION
Part of a sweep across the HAR-consuming plugins; same problem class as Webperf-se/webperf_core#1557 / #1558, Webperf-se/plugin-pagenotfound#156, Webperf-se/plugin-css#159 and Webperf-se/plugin-html#130.

## Problem

Concurrent browsertime runs on one host can race for the same Chrome DevTools port; the crossed CDP session records the other run's page navigation into this run's HAR, so the HAR can contain more than one page.

`transform2SimplifiedData` collected every JavaScript response body and every inline `<script>` from every HTML document in the whole HAR into the eslint set, so a crossed-in recording attributes the other website's JavaScript issues to the tested website.

## Fix

New `getFirstPageEntries(url, harData)`:
1. keeps only entries whose `pageref` belongs to the first page in the HAR's `pages` array;
2. verifies the first recorded request's hostname matches the tested URL's hostname (`new URL(...)` punycodes IDN hostnames on both sides) — on mismatch nothing is analyzed.

Cross-domain scripts loaded *by the tested page* are still linted (`pageref` groups by initiating page, not by domain). HARs without a `pages` array and entries without `pageref` behave exactly as before.

## Validation

Synthetic crossed HAR: only the tested page's external and inline scripts are collected, foreign scripts excluded; origin mismatch yields an empty analysis; legacy HAR without `pages` unchanged; `eslint` clean.